### PR TITLE
Several Fixes and Improvements

### DIFF
--- a/src/saltext/cli/__main__.py
+++ b/src/saltext/cli/__main__.py
@@ -89,7 +89,7 @@ SALT_LOADERS = (
     expose_value=True,
 )
 @click.option(
-    "-V", "--salt-version", help="The minimum Salt version to target", default="3002.6", type=str
+    "-V", "--salt-version", help="The minimum Salt version to target", default="3003", type=str
 )
 @click.option(
     "-l",

--- a/src/saltext/cli/__main__.py
+++ b/src/saltext/cli/__main__.py
@@ -72,7 +72,14 @@ SALT_LOADERS = (
 @click.option("--source-url", help="Project Source URL", type=PUBLIC_URL)
 @click.option("--tracker-url", help="Project Tracker URL", type=PUBLIC_URL)
 @click.option("--docs-url", help="Project Documentation URL", type=PUBLIC_URL)
-@click.option("--package-name", help="Project Package name 'saltex.<package-name>'", type=str)
+@click.option("--package-name", help="Project Package name 'saltext.<package-name>'", type=str)
+@click.option(
+    "--no-saltext-namespace",
+    help="Don't use the 'saltext' package namespace",
+    is_flag=True,
+    default=False,
+    expose_value=True,
+)
 @click.option(
     "-F",
     "--force-overwrite",
@@ -122,6 +129,7 @@ def main(
     dest: str,
     salt_version: str,
     force_overwrite: bool,
+    no_saltext_namespace: bool,
 ):
     destdir: pathlib.Path = pathlib.Path(dest)
 
@@ -134,6 +142,16 @@ def main(
         "salt_version": salt_version,
         "copyright_year": datetime.datetime.today().year,
     }
+    if no_saltext_namespace is False:
+        package_namespace = "saltext"
+        package_namespace_pkg = f"{package_namespace}."
+        package_namespace_path = f"{package_namespace}/"
+        templating_context["package_namespace"] = "saltext"
+    else:
+        package_namespace = package_namespace_path = package_namespace_pkg = ""
+        templating_context["package_namespace"] = ""
+    templating_context["package_namespace_pkg"] = package_namespace_pkg
+    templating_context["package_namespace_path"] = package_namespace_path
 
     if not package_name:
         package_name = project_name.replace(" ", "_").replace("-", "_")
@@ -212,7 +230,7 @@ def main(
             contents = Template(contents).render(**templating_context)
         dst.write_text(contents.rstrip() + "\n")
 
-    loaders_package_path = destdir / "src" / "saltext" / package_name
+    loaders_package_path = destdir / "src" / package_namespace / package_name
     loaders_package_path.mkdir(0o755, parents=True)
     loaders_package_path.joinpath("__init__.py").write_text(
         Template(PACKAGE_INIT).render(**templating_context).rstrip() + "\n"
@@ -282,7 +300,7 @@ def main(
         "newer, edit 'setup.cfg', read the comment around 'options.entry-points', "
         "and then run the following command:"
     )
-    click.secho(f"  rm src/saltext/{package_name}/loader.py")
+    click.secho(f"  rm src/{package_namespace_path}{package_name}/loader.py")
     click.secho("You should now run the following commands:")
     click.secho(f"  python3 -m venv .env --prompt {project_name!r}")
     click.secho("  source .env/bin/activate")

--- a/src/saltext/cli/__main__.py
+++ b/src/saltext/cli/__main__.py
@@ -143,14 +143,14 @@ def main(
         "salt_version": salt_version,
         "copyright_year": datetime.datetime.today().year,
     }
-    if no_saltext_namespace is False:
+    if no_saltext_namespace:
+        package_namespace = package_namespace_path = package_namespace_pkg = ""
+        templating_context["package_namespace"] = ""
+    else:
         package_namespace = "saltext"
         package_namespace_pkg = f"{package_namespace}."
         package_namespace_path = f"{package_namespace}/"
         templating_context["package_namespace"] = "saltext"
-    else:
-        package_namespace = package_namespace_path = package_namespace_pkg = ""
-        templating_context["package_namespace"] = ""
     templating_context["package_namespace_pkg"] = package_namespace_pkg
     templating_context["package_namespace_path"] = package_namespace_path
 

--- a/src/saltext/cli/__main__.py
+++ b/src/saltext/cli/__main__.py
@@ -7,6 +7,7 @@ from typing import Optional
 from typing import Tuple
 
 import click
+import jinja2.exceptions
 from click_params import PUBLIC_URL
 from click_params import SLUG
 from jinja2 import Template
@@ -227,7 +228,14 @@ def main(
             dst = dst.with_suffix(".new")
         contents = src.read_text()
         if src.name.endswith(".j2"):
-            contents = Template(contents).render(**templating_context)
+            try:
+                contents = Template(contents).render(**templating_context)
+            except jinja2.exceptions.TemplateError as exc:
+                click.secho(
+                    f"Failed to render template {src}: {exc}",
+                    fg="bright_red",
+                )
+                raise
         dst.write_text(contents.rstrip() + "\n")
 
     loaders_package_path = destdir / "src" / package_namespace / package_name

--- a/src/saltext/cli/project/.coveragerc.j2
+++ b/src/saltext/cli/project/.coveragerc.j2
@@ -36,7 +36,7 @@ ignore_errors = True
 
 [paths]
 source =
-  saltext/{{ package_name }}
-  src/saltext/{{ package_name }}
+  {{ package_namespace_path }}{{ package_name }}
+  src/{{ package_namespace_path }}{{ package_name }}
 testsuite =
   tests/

--- a/src/saltext/cli/project/.gitignore.j2
+++ b/src/saltext/cli/project/.gitignore.j2
@@ -129,7 +129,7 @@ dmypy.json
 .pyre/
 
 # Ignore the setuptools_scm auto-generated version module
-src/saltext/{{ package_name }}/version.py
+src/{{ package_namespace_path }}{{ package_name }}/version.py
 
 # Ignore CI generated artifacts
 artifacts/

--- a/src/saltext/cli/project/.pre-commit-config.yaml.j2
+++ b/src/saltext/cli/project/.pre-commit-config.yaml.j2
@@ -25,7 +25,7 @@ repos:
         name: Check CLI examples on execution modules
         entry: python .pre-commit-hooks/check-cli-examples.py
         language: system
-        files: ^src/saltext/{{ package_name }}/modules/.*\.py$
+        files: ^src/{{ package_namespace_path }}{{ package_name }}/modules/.*\.py$
 
   - repo: local
     hooks:
@@ -42,7 +42,7 @@ repos:
       - id: salt-rewrite
         alias: rewrite-docstrings
         name: Salt extensions docstrings auto-fixes
-        files: ^src/saltext/{{ package_name }}/.*\.py$
+        files: ^src/{{ package_namespace_path }}{{ package_name }}/.*\.py$
         args: [--silent]
 
   - repo: https://github.com/s0undt3ch/salt-rewrite
@@ -63,7 +63,7 @@ repos:
         args: [
           --py36-plus
         ]
-        exclude: src/saltext/{{ package_name }}/version.py
+        exclude: src/{{ package_namespace_path }}{{ package_name }}/version.py
 
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v2.6.0
@@ -72,21 +72,21 @@ repos:
         args: [
           --py3-plus,
         ]
-        exclude: src/saltext/{{ package_name }}/version.py
+        exclude: src/{{ package_namespace_path }}{{ package_name }}/version.py
 
   - repo: https://github.com/psf/black
     rev: 21.7b0
     hooks:
       - id: black
         args: [-l 100]
-        exclude: src/saltext/{{ package_name }}/version.py
+        exclude: src/{{ package_namespace_path }}{{ package_name }}/version.py
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.10.0
     hooks:
       - id: blacken-docs
         args: [--skip-errors]
-        files: ^(docs/.*\.rst|src/saltext/{{ package_name }}/.*\.py)$
+        files: ^(docs/.*\.rst|src/{{ package_namespace_path }}{{ package_name }}/.*\.py)$
         additional_dependencies: [black==21.7b0]
   # <---- Formatting -----------------------------------------------------------------------------
 
@@ -98,7 +98,7 @@ repos:
         alias: bandit-salt
         name: Run bandit against the code base
         args: [--silent, -lll, --skip, B701]
-        exclude: src/saltext/{{ package_name }}/version.py
+        exclude: src/{{ package_namespace_path }}{{ package_name }}/version.py
   - repo: https://github.com/PyCQA/bandit
     rev: "1.7.0"
     hooks:

--- a/src/saltext/cli/project/.pre-commit-hooks/check-cli-examples.py.j2
+++ b/src/saltext/cli/project/.pre-commit-hooks/check-cli-examples.py.j2
@@ -4,7 +4,7 @@ import re
 import sys
 
 CODE_ROOT = pathlib.Path(__file__).resolve().parent.parent
-EXECUTION_MODULES_PATH = CODE_ROOT / "src" / "saltext" / "{{ package_name }}" / "modules"
+EXECUTION_MODULES_PATH = CODE_ROOT / "src" / {% if package_namespace -%} "{{ package_namespace}}" / {% endif -%}" {{ package_name }}" / "modules"
 
 
 def check_cli_examples(files):

--- a/src/saltext/cli/project/.pre-commit-hooks/make-autodocs.py.j2
+++ b/src/saltext/cli/project/.pre-commit-hooks/make-autodocs.py.j2
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 repo_path = Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode().strip())
-src_dir = repo_path / "src" / "saltext" / "{{ project_name }}"
+src_dir = repo_path / "src" / {% if package_namespace -%}" {{ package_namespace}}" / {% endif -%} "{{ project_name }}"
 doc_dir = repo_path / "docs"
 
 docs_by_kind = {}
@@ -15,7 +15,7 @@ def make_import_path(path):
     return ".".join(path.with_suffix("").parts[-4:])
 
 
-for path in Path(__file__).parent.parent.joinpath("src/saltext/{{ project_name }}/").glob("*/*.py"):
+for path in Path(__file__).parent.parent.joinpath("src/{{ package_namespace_path }}{{ project_name }}/").glob("*/*.py"):
     if path.name != "__init__.py":
         kind = path.parent.name
         docs_by_kind.setdefault(kind, set()).add(path)
@@ -45,7 +45,7 @@ for kind in docs_by_kind:
 
     all_rst.write_text(
         f"""
-.. all-saltext.{{ project_name }}.{kind}:
+.. all-{%- if package_namespace %}{{ package_namespace}}.{%- endif %}{{ project_name }}.{kind}:
 
 {header}
 

--- a/src/saltext/cli/project/docs/conf.py.j2
+++ b/src/saltext/cli/project/docs/conf.py.j2
@@ -26,14 +26,14 @@ except NameError:
     docs_basepath = os.path.abspath(os.path.dirname("."))
 
 addtl_paths = (
-    os.path.join(os.pardir, "src"),  # saltext.ttp itself (for autodoc)
+    os.path.join(os.pardir, "src"),  # {{ package_namespace_pkg }}{{ project_name }} itself (for autodoc)
     "_ext",  # custom Sphinx extensions
 )
 
 for addtl_path in addtl_paths:
     sys.path.insert(0, os.path.abspath(os.path.join(docs_basepath, addtl_path)))
 
-dist = distribution("saltext.{{ project_name }}")
+dist = distribution("{{ package_namespace_pkg }}{{ project_name }}")
 
 
 # -- Project information -----------------------------------------------------

--- a/src/saltext/cli/project/noxfile.py.j2
+++ b/src/saltext/cli/project/noxfile.py.j2
@@ -520,7 +520,10 @@ def gen_api_docs(session):
         install_source=True,
         install_extras=["docs"],
     )
-    shutil.rmtree("docs/ref")
+    try:
+        shutil.rmtree("docs/ref")
+    except FileNotFoundError:
+        pass
     session.run(
         "sphinx-apidoc",
         "--implicit-namespaces",

--- a/src/saltext/cli/project/noxfile.py.j2
+++ b/src/saltext/cli/project/noxfile.py.j2
@@ -30,7 +30,7 @@ SKIP_REQUIREMENTS_INSTALL = "SKIP_REQUIREMENTS_INSTALL" in os.environ
 EXTRA_REQUIREMENTS_INSTALL = os.environ.get("EXTRA_REQUIREMENTS_INSTALL")
 
 COVERAGE_VERSION_REQUIREMENT = "coverage==5.2"
-SALT_REQUIREMENT = os.environ.get("SALT_REQUIREMENT") or "salt>=3003"
+SALT_REQUIREMENT = os.environ.get("SALT_REQUIREMENT") or "salt>={{ salt_version }}"
 if SALT_REQUIREMENT == "salt==master":
     SALT_REQUIREMENT = "git+https://github.com/saltstack/salt.git@master"
 

--- a/src/saltext/cli/project/noxfile.py.j2
+++ b/src/saltext/cli/project/noxfile.py.j2
@@ -20,7 +20,7 @@ nox.options.reuse_existing_virtualenvs = True
 nox.options.error_on_missing_interpreters = False
 
 # Python versions to test against
-PYTHON_VERSIONS = ("3", "3.5", "3.6", "3.7", "3.8", "3.9")
+PYTHON_VERSIONS = ("3", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10")
 # Be verbose when running under a CI context
 CI_RUN = (
     os.environ.get("JENKINS_URL") or os.environ.get("CI") or os.environ.get("DRONE") is not None
@@ -30,7 +30,7 @@ SKIP_REQUIREMENTS_INSTALL = "SKIP_REQUIREMENTS_INSTALL" in os.environ
 EXTRA_REQUIREMENTS_INSTALL = os.environ.get("EXTRA_REQUIREMENTS_INSTALL")
 
 COVERAGE_VERSION_REQUIREMENT = "coverage==5.2"
-SALT_REQUIREMENT = os.environ.get("SALT_REQUIREMENT") or "salt>=3003rc1"
+SALT_REQUIREMENT = os.environ.get("SALT_REQUIREMENT") or "salt>=3003"
 if SALT_REQUIREMENT == "salt==master":
     SALT_REQUIREMENT = "git+https://github.com/saltstack/salt.git@master"
 
@@ -196,7 +196,7 @@ def tests(session):
             "-o",
             str(COVERAGE_REPORT_PROJECT),
             "--omit=tests/*",
-            "--include=src/saltext/{{ package_name }}/*",
+            "--include=src/{{ package_namespace_path }}{{ package_name }}/*",
         )
         # Generate report for tests code coverage
         session.run(
@@ -204,16 +204,16 @@ def tests(session):
             "xml",
             "-o",
             str(COVERAGE_REPORT_TESTS),
-            "--omit=src/saltext/{{ package_name }}/*",
+            "--omit=src/{{ package_namespace_path }}{{ package_name }}/*",
             "--include=tests/*",
         )
         try:
-            session.run("coverage", "report", "--show-missing", "--include=src/saltext/{{ package_name }}/*")
+            session.run("coverage", "report", "--show-missing", "--include=src/{{ package_namespace_path }}{{ package_name }}/*")
             # If you also want to display the code coverage report on the CLI
             # for the tests, comment the call above and uncomment the line below
             # session.run(
             #    "coverage", "report", "--show-missing",
-            #    "--include=src/saltext/{{ package_name }}/*,tests/*"
+            #    "--include=src/{{ package_namespace_path }}{{ package_name }}/*,tests/*"
             # )
         finally:
             # Move the coverage DB to artifacts/coverage in order for it to be archived by CI
@@ -527,6 +527,6 @@ def gen_api_docs(session):
         "--module-first",
         "-o",
         "docs/ref/",
-        "src/saltext",
-        "src/saltext/{{ package_name }}/config/schemas",
+        "src/{{ package_namespace }}",
+        "src/{{ package_namespace_path }}{{ package_name }}/config/schemas",
     )

--- a/src/saltext/cli/project/pyproject.toml.j2
+++ b/src/saltext/cli/project/pyproject.toml.j2
@@ -3,7 +3,7 @@ requires = ["setuptools>=50.3.2", "wheel", "setuptools-declarative-requirements"
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-write_to = "src/saltext/{{ package_name }}/version.py"
+write_to = "src/{{ package_namespace_path }}{{ package_name }}/version.py"
 write_to_template = "__version__ = \"{version}\""
 
 [tool.black]

--- a/src/saltext/cli/project/setup.cfg.j2
+++ b/src/saltext/cli/project/setup.cfg.j2
@@ -48,7 +48,7 @@ setup_requires =
   setuptools_scm[toml]>=3.4
   setuptools-declarative-requirements
 install_requires =
-  salt>=3003
+  salt>={{ salt_version }}
   # Add other module install requirements above this line
 
 [options.packages.find]

--- a/src/saltext/cli/project/setup.cfg.j2
+++ b/src/saltext/cli/project/setup.cfg.j2
@@ -69,23 +69,23 @@ salt.loader=
 
 
 [options.extras_require]
-  tests =
-    pytest==6.2.4
-    pytest-salt-factories==0.911.0
-  dev =
-    nox
-    pre-commit==2.13.0
-    pylint
-    SaltPyLint
-  docs =
-    sphinx
-    furo
-    sphinx-copybutton
-    sphinx-prompt
-    sphinxcontrib-spelling
-    importlib_metadata; python_version < "3.8"
-  docsauto =
-    sphinx-autobuild
+tests =
+  pytest==6.2.4
+  pytest-salt-factories==0.911.0
+dev =
+  nox
+  pre-commit==2.13.0
+  pylint
+  SaltPyLint
+docs =
+  sphinx
+  furo
+  sphinx-copybutton
+  sphinx-prompt
+  sphinxcontrib-spelling
+  importlib_metadata; python_version < "3.8"
+docsauto =
+  sphinx-autobuild
 
 [bdist_wheel]
 # Use this option if your package is pure-python

--- a/src/saltext/cli/project/setup.cfg.j2
+++ b/src/saltext/cli/project/setup.cfg.j2
@@ -71,9 +71,9 @@ salt.loader=
 [options.extras_require]
   tests =
     pytest==6.2.4
-    pytest-salt-factories==0.906.0
+    pytest-salt-factories==0.911.0
   dev =
-    nox==2021.6.12
+    nox
     pre-commit==2.13.0
     pylint
     SaltPyLint

--- a/src/saltext/cli/project/setup.cfg.j2
+++ b/src/saltext/cli/project/setup.cfg.j2
@@ -1,5 +1,5 @@
 [metadata]
-name = saltext.{{ project_name }}
+name = {{ package_namespace_pkg }}{{ project_name }}
 description = {{ summary }}
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -60,12 +60,12 @@ exclude =
 #[options.entry_points]
 #salt.loader=
 #{%- for loader_name in loaders %}
-#  {{ loader_name }}_dirs = saltext.{{ package_name }}.loader:get_{{ loader_name }}_dirs
+#  {{ loader_name }}_dirs = {{ package_namespace_pkg }}{{ package_name }}.loader:get_{{ loader_name }}_dirs
 #{%- endfor %}
 
 [options.entry_points]
 salt.loader=
-  saltext.{{ project_name }} = saltext.{{ package_name }}
+  {{ package_namespace_pkg }}{{ project_name }} = {{ package_namespace_pkg }}{{ package_name }}
 
 
 [options.extras_require]

--- a/src/saltext/cli/project/tests/conftest.py.j2
+++ b/src/saltext/cli/project/tests/conftest.py.j2
@@ -20,9 +20,9 @@ def salt_factories_config():
 
 @pytest.fixture(scope="package")
 def master(salt_factories):
-    return salt_factories.get_salt_master_daemon(random_string("master-"))
+    return salt_factories.salt_master_daemon(random_string("master-"))
 
 
 @pytest.fixture(scope="package")
 def minion(master):
-    return master.get_salt_minion_daemon(random_string("minion-"))
+    return master.salt_minion_daemon(random_string("minion-"))

--- a/src/saltext/cli/project/tests/conftest.py.j2
+++ b/src/saltext/cli/project/tests/conftest.py.j2
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from saltext.{{ package_name }} import PACKAGE_ROOT
+from {{ package_namespace_pkg }}{{ package_name }} import PACKAGE_ROOT
 from saltfactories.utils import random_string
 
 

--- a/src/saltext/cli/project/tests/integration/conftest.py
+++ b/src/saltext/cli/project/tests/integration/conftest.py
@@ -15,14 +15,14 @@ def minion(minion):
 
 @pytest.fixture
 def salt_run_cli(master):
-    return master.get_salt_run_cli()
+    return master.salt_run_cli()
 
 
 @pytest.fixture
 def salt_cli(master):
-    return master.get_salt_cli()
+    return master.salt_cli()
 
 
 @pytest.fixture
 def salt_call_cli(minion):
-    return minion.get_salt_call_cli()
+    return minion.salt_call_cli()

--- a/src/saltext/cli/templates.py
+++ b/src/saltext/cli/templates.py
@@ -137,7 +137,7 @@ def exampled(name):
 LOADER_MODULE_UNIT_TEST_TEMPLATE = """\
 import pytest
 import salt.modules.test as testmod
-import saltext.{{ package_name }}.{{ loader.rstrip("s") + "s" }}.{{ package_name }}_mod as {{ package_name }}_module
+import {{ package_namespace_pkg }}{{ package_name }}.{{ loader.rstrip("s") + "s" }}.{{ package_name }}_mod as {{ package_name }}_module
 
 
 @pytest.fixture
@@ -158,8 +158,8 @@ def test_replace_this_this_with_something_meaningful():
 LOADER_STATE_UNIT_TEST_TEMPLATE = """\
 import pytest
 import salt.modules.test as testmod
-import saltext.{{ package_name }}.modules.{{ package_name }}_mod as {{ package_name }}_module
-import saltext.{{ package_name }}.{{ loader.rstrip("s") + "s" }}.{{ package_name }}_mod as {{ package_name }}_state
+import {{ package_namespace_pkg }}{{ package_name }}.modules.{{ package_name }}_mod as {{ package_name }}_module
+import {{ package_namespace_pkg }}{{ package_name }}.{{ loader.rstrip("s") + "s" }}.{{ package_name }}_mod as {{ package_name }}_state
 
 
 @pytest.fixture
@@ -192,7 +192,7 @@ def test_replace_this_this_with_something_meaningful():
 LOADER_UNIT_TEST_TEMPLATE = """\
 {%- set loader_name = loader.rstrip("s") %}
 import pytest
-import saltext.{{ package_name }}.{{ loader.rstrip("s") + "s" }}.{{ package_name }}_mod as {{ package_name }}_{{ loader_name }}
+import {{ package_namespace_pkg }}{{ package_name }}.{{ loader.rstrip("s") + "s" }}.{{ package_name }}_mod as {{ package_name }}_{{ loader_name }}
 
 
 @pytest.fixture


### PR DESCRIPTION
* Allow not creating ``saltext`` namespaced packages
* Use provided salt version from the CLI when rendering templates
* Bump ``pytest-salt-factories`` version
* Remove version lock from ``nox``
* Show an error when failing to render a Jinja templated file
* Dedent ``extras_require``