### PR TITLE
couple fixes

### DIFF
--- a/src/saltext/cli/project/.pylintrc
+++ b/src/saltext/cli/project/.pylintrc
@@ -12,7 +12,7 @@ profile=no
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS,_version.py
+ignore=CVS,_version.py,noxfile.py
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/src/saltext/cli/project/setup.cfg.j2
+++ b/src/saltext/cli/project/setup.cfg.j2
@@ -72,13 +72,15 @@ salt.loader=
 tests =
   pytest==6.2.4
   pytest-salt-factories==0.911.0
+  jinja2<3.1
 dev =
   nox
   pre-commit==2.13.0
   pylint
   SaltPyLint
 docs =
-  sphinx
+  sphinx>=3.5.1
+  jinja2<3.1
   furo
   sphinx-copybutton
   sphinx-prompt


### PR DESCRIPTION
copy jinja and sphinx dependancies from Salt repo.  Don't run lint against noxfile.py.