### PR TITLE
Usability fixes

### DIFF
--- a/src/saltext/cli/project/.pylintrc
+++ b/src/saltext/cli/project/.pylintrc
@@ -632,7 +632,28 @@ signature-mutators=
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid defining new builtins when possible.
-additional-builtins=
+additional-builtins=__opts__,
+  __salt__,
+  __pillar__,
+  __grains__,
+  __context__,
+  __runner__,
+  __ret__,
+  __env__,
+  __low__,
+  __states__,
+  __lowstate__,
+  __running__,
+  __active_provider_name__,
+  __master_opts__,
+  __jid_event__,
+  __instance_id__,
+  __salt_system_encoding__,
+  __proxy__,
+  __serializers__,
+  __reg__,
+  __executors__,
+  __events__
 
 # Tells whether unused global variables should be treated as a violation.
 allow-global-unused-variables=yes

--- a/src/saltext/cli/project/tests/conftest.py.j2
+++ b/src/saltext/cli/project/tests/conftest.py.j2
@@ -8,12 +8,11 @@ from saltfactories.utils import random_string
 @pytest.fixture(scope="session")
 def salt_factories_config():
     """
-    Return a dictionary with the keyworkd arguments for FactoriesManager
+    Return a dictionary with the keyword arguments for FactoriesManager
     """
     return {
         "code_dir": str(PACKAGE_ROOT),
         "inject_coverage": "COVERAGE_PROCESS_START" in os.environ,
-        "inject_sitecustomize": "COVERAGE_PROCESS_START" in os.environ,
         "start_timeout": 120 if os.environ.get("CI") else 60,
     }
 

--- a/src/saltext/cli/project/tests/conftest.py.j2
+++ b/src/saltext/cli/project/tests/conftest.py.j2
@@ -1,8 +1,20 @@
+import logging
 import os
 
 import pytest
 from {{ package_namespace_pkg }}{{ package_name }} import PACKAGE_ROOT
 from saltfactories.utils import random_string
+
+
+# Reset the root logger to its default level(because salt changed it)
+logging.root.setLevel(logging.WARNING)
+
+
+# This swallows all logging to stdout.
+# To show select logs, set --log-cli-level=<level>
+for handler in logging.root.handlers[:]:
+    logging.root.removeHandler(handler)
+    handler.close()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Currently, after generating an extension,

a) pre-commit pylint will fail because the dunders are not in the additional-builtins config
b) running the tests will yield a `TypeError: FactoriesManager.__init__() got an unexpected keyword argument 'inject_coverage'`
c) by default, all debug logs will be dumped to stdout during testing (unlike in the regular test suite)

This fixes the aforementioned usability issues.