### PR TITLE
YAML Requires Spaces after Colons

### DIFF
--- a/src/saltext/cli/project/.pre-commit-config.yaml.j2
+++ b/src/saltext/cli/project/.pre-commit-config.yaml.j2
@@ -118,7 +118,7 @@ repos:
         alias: lint-src
         name: Lint Source Code
         files: ^((setup|noxfile)|src/.*)\.py$
-        require_serial:true
+        require_serial: true
         args:
           - -e
           - lint-code-pre-commit
@@ -131,7 +131,7 @@ repos:
         alias: lint-tests
         name: Lint Tests
         files: ^tests/.*\.py$
-        require_serial:true
+        require_serial: true
         args:
           - -e
           - lint-tests-pre-commit


### PR DESCRIPTION
> Mappings use a colon and space (": ") to mark each key: value pair.

The lack of space causes parsing issues for pre-commit on my installation, and adding the appropriate space fixes it.